### PR TITLE
Make chunkly_start and chunkly_squash compatible with noclobber option of Zsh

### DIFF
--- a/zsh/plugins/chunkly/chunkly.plugin.zsh
+++ b/zsh/plugins/chunkly/chunkly.plugin.zsh
@@ -183,11 +183,11 @@ EOC
 }
 
 chunkly_mark_as_started() {
-  date --utc +%s > ~/.chunkly/last_chunk_started_at
+  date --utc +%s >| ~/.chunkly/last_chunk_started_at
 }
 
 chunkly_mark_as_squashed() {
-  date --utc +%s > ~/.chunkly/last_chunk_squashed_at
+  date --utc +%s >| ~/.chunkly/last_chunk_squashed_at
 }
 
 chunkly_start() {


### PR DESCRIPTION
Before this patch this happens:

$ set -o noclobber
$ chunkly_squash
chunkly_mark_as_squashed:1: file exists: /Users/andrea/.chunkly/last_chunk_squashed_at

After this patch noclobber chunkly_start and _squash works with or without noclobber.
